### PR TITLE
change http -> https in urlMirrorService (httpbin.org)

### DIFF
--- a/src/Example_18_Ellie.elm
+++ b/src/Example_18_Ellie.elm
@@ -633,7 +633,7 @@ viewFooter version =
 
 urlMirrorService : String
 urlMirrorService =
-    "http://httpbin.org/post"
+    "https://httpbin.org/post"
 
 
 viewHeader : String -> Html msg

--- a/src/Example_8_Ellie.elm
+++ b/src/Example_8_Ellie.elm
@@ -243,7 +243,7 @@ viewFooter version =
 
 urlMirrorService : String
 urlMirrorService =
-    "http://httpbin.org/post"
+    "https://httpbin.org/post"
 
 
 viewHeader : String -> Html msg

--- a/src/Utils.elm
+++ b/src/Utils.elm
@@ -44,7 +44,7 @@ viewFooter version =
 
 urlMirrorService : String
 urlMirrorService =
-    "http://httpbin.org/post"
+    "https://httpbin.org/post"
 
 
 viewHeader : String -> Html msg


### PR DESCRIPTION
Otherwise, at least in Ellie version form submission fails with "NetworkError". Don't know if it's Elm's fault or httpbin.org.

Form submission in [Example_18_Ellie.elm](../blob/master/src/Example_18_Ellie.elm) works fine in [Ellie](https://ellie-app.com/3ncFD4zQPa1/0) when urlMirrorService declared as below:
```elm
urlMirrorService =
    "https://httpbin.org/post"
```